### PR TITLE
Verwijzingen naar geluidberekeningsobjecten als featuremember binnen geluidgegevenscollectie verwijderd. Deze horen daar niet.

### DIFF
--- a/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_gemeenteweg_zonder_spoor_vaststelling.gml
+++ b/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_gemeenteweg_zonder_spoor_vaststelling.gml
@@ -2870,7 +2870,6 @@
       </img:herkomstCollectie>
       <img:systematiek>BGE</img:systematiek>
 	  <img:geluidaandachtsgebied xlink:href="#NL.img.22224444.GAG-198443.1"></img:geluidaandachtsgebied>
-      <img:featureMember xlink:href="NL.img.22224444.Geluidberekening-BGE-1.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.22224444.BGE-977.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.22224444.Document-M_gemeenteweg_rijlijnen_2D_ge1000.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.22224444.Wegdeel-877.1"></img:featureMember>

--- a/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_hoofdspoor_monitoringresultaat.gml
+++ b/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_hoofdspoor_monitoringresultaat.gml
@@ -24,7 +24,6 @@
       </img:herkomstCollectie>
       <img:systematiek>GPP</img:systematiek>
       <img:featureMember xlink:href="#NL.img.30124359.Nalevingsverslag-2018.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.30124359.gbo-monitoring-2018.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.mtr-2018-12999.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.mtr-2018-12479.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.mtr-2018-12480.1"></img:featureMember>

--- a/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_hoofdspoor_vaststelling.gml
+++ b/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_hoofdspoor_vaststelling.gml
@@ -4117,15 +4117,10 @@ Dit voorbeeldbestand is een voorbeeld voor de geluidbron hoofdspoor, van het typ
       <img:featureMember xlink:href="#NL.img.30124359.gss1349985.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.gpp30806.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.dv20-05-2019.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.30124359.gbo20-05-2019.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.dv24-06-2014.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.30124359.gbo24-06-2014.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.dv15-09-2017.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.30124359.gbo15-09-2017.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.dv10-11-2014.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.30124359.gbo10-11-2014.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.dv01-07-2015.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.30124359.gbo01-07-2015.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.gpp13012.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.gpp13008.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.30124359.gpp13015.1"></img:featureMember>

--- a/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_luchtvaart.gml
+++ b/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_luchtvaart.gml
@@ -23,7 +23,6 @@ Dit voorbeeldbestand is een voorbeeld voor de geluidbron luchtvaart, van het typ
       <img:systematiek>anders</img:systematiek>
       <img:featureMember xlink:href="#NL.img.12345678.Besluit-1.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.12345678.Luchthaventerrein-1.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.12345678.Geluidberekeningobject-1.1"></img:featureMember>
     </img:Geluidgegevenscollectie>
   </gml:featureMember>
   <gml:featureMember>

--- a/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_provinciale_weg_vaststelling.gml
+++ b/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_provinciale_weg_vaststelling.gml
@@ -166,7 +166,6 @@ Dit voorbeeldbestand is een voorbeeld voor de geluidbron provinciale weg, van he
 	  <img:featureMember xlink:href="#NL.img.44441111.Geluidscherm-5495-288.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.44441111.Document-M_Provincieweg.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.44441111.Wegdeel-8290.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.44441111.Geluidberekening-M_Provincieweg.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.44441111.Wegdeel-8185.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.44441111.Wegdeel-931.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.44441111.Wegdeel-873.1"></img:featureMember>

--- a/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_rijksweg_monitoringresultaat.gml
+++ b/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_rijksweg_monitoringresultaat.gml
@@ -58,7 +58,6 @@
       <img:systematiek>GPP</img:systematiek>
       <img:featureMember xlink:href="#NL.img.53824291.mtr-2018-33880.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.53824291.dv-monitoring-2018.1"></img:featureMember>
-      <img:featureMember xlink:href="#NL.img.53824291.gbo-monitoring-2018.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.53824291.mtr-2018-33993.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.53824291.mtr-2018-33887.1"></img:featureMember>
       <img:featureMember xlink:href="#NL.img.53824291.mtr-2018-33985.1"></img:featureMember>

--- a/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_rijksweg_vaststelling.gml
+++ b/voorbeeldbestanden/IMGeluid 1.1/Aanleverbestand_rijksweg_vaststelling.gml
@@ -324,7 +324,6 @@ werkelijkheid. Dit voorbeeldbestand is een voorbeeld voor de geluidbron rijksweg
             <img:featureMember xlink:href="#NL.img.53824291.wd41775.1"></img:featureMember>
             <img:featureMember xlink:href="#NL.img.53824291.wd40180.1"></img:featureMember>
             <img:featureMember xlink:href="#NL.img.53824291.wd39235.1"></img:featureMember>
-            <img:featureMember xlink:href="#NL.img.53824291.gbo20190717-Verni.1"></img:featureMember>
             <img:featureMember xlink:href="#NL.img.53824291.dv20190717-Verni.1"></img:featureMember>
             <img:featureMember xlink:href="#NL.img.53824291.GPP-33999.1"></img:featureMember>
             <img:featureMember xlink:href="#NL.img.53824291.GPP-34000.1"></img:featureMember>


### PR DESCRIPTION
Verwijzingen naar geluidberekeningsobjecten als featuremember binnen geluidgegevenscollectie verwijderd. Deze horen daar niet.